### PR TITLE
fixing dplyr error in reactive() block

### DIFF
--- a/sqlite/app.R
+++ b/sqlite/app.R
@@ -107,7 +107,7 @@ server <- function(input, output, session) {
   # the input variables
   base_flights <- reactive({
     res <- flights %>%
-      filter(carrier == input$airline) %>%
+      filter(carrier == local(input$airline)) %>%
       left_join(airlines, by = "carrier") %>%
       rename(airline = name) %>%
       left_join(airports, by = c("origin" = "faa")) %>%
@@ -115,7 +115,7 @@ server <- function(input, output, session) {
       select(-lat, -lon, -alt, -tz, -dst) %>%
       left_join(airports, by = c("dest" = "faa")) %>%
       rename(dest_name = name)
-    if (input$month != 99) res <- filter(res, month == input$month)
+    if (local(input$month) != 99) res <- filter(res, month == local(input$month))
     res
   })
 


### PR DESCRIPTION
An update in dbplyr now raises an error in the sqlite version of the dashboard:

> Cannot embed a reactiveValues() object in a SQL query.
> 
> If you are seeing this error in code that used to work, the most likely
> cause is a change dbplyr 1.4.0. Previously `df$x` or `df[[y]]` implied
> that `df` was a local variable, but now you must make that explict with
> `!!` or `local()`, e.g., `!!df$x` or `local(df[["y"]))

Fixed error by following instructions.

```r
> sessionInfo()
R version 3.6.0 (2019-04-26)
Platform: x86_64-apple-darwin15.6.0 (64-bit)
Running under: macOS Mojave 10.14.6

Matrix products: default
BLAS:   /Library/Frameworks/R.framework/Versions/3.6/Resources/lib/libRblas.0.dylib
LAPACK: /Library/Frameworks/R.framework/Versions/3.6/Resources/lib/libRlapack.dylib

locale:
[1] en_GB.UTF-8/en_GB.UTF-8/en_GB.UTF-8/C/en_GB.UTF-8/en_GB.UTF-8

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base

other attached packages:
 [1] RSQLite_2.1.1        dbplyr_1.4.2         DBI_1.0.0
 [4] r2d3_0.2.3           DT_0.6               stringr_1.4.0
 [7] rlang_0.3.4          purrr_0.3.2          dplyr_0.8.0.1
[10] shinydashboard_0.7.1 shiny_1.3.2

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.1       pillar_1.3.1     compiler_3.6.0   later_0.8.0
 [5] tools_3.6.0      digest_0.6.18    bit_1.1-14       jsonlite_1.6
 [9] memoise_1.1.0    tibble_2.1.1     pkgconfig_2.0.2  rstudioapi_0.10
[13] xfun_0.6         knitr_1.22       htmlwidgets_1.3  bit64_0.9-7
[17] tidyselect_0.2.5 glue_1.3.1       R6_2.4.0         blob_1.1.1
[21] magrittr_1.5     promises_1.0.1   htmltools_0.3.6  assertthat_0.2.1
[25] mime_0.6         xtable_1.8-4     httpuv_1.5.1     stringi_1.4.3
[29] crayon_1.3.4
```
